### PR TITLE
Fixed beautification and substitution mistakes

### DIFF
--- a/Scripts/content/AI/Test_Skripts/CharacterHelper.d
+++ b/Scripts/content/AI/Test_Skripts/CharacterHelper.d
@@ -903,7 +903,7 @@ func void CH_Training_STR_Info()
 {
 	Info_ClearChoices(CH_Training_STR);
 
-	Info_AddChoice(CH_Training_STR, DIALOG_ENDE, CH_Training_STR_BACK);
+	Info_AddChoice(CH_Training_STR, DIALOG_BACK, CH_Training_STR_BACK);
 	Info_AddChoice(CH_Training_STR, "Stärke (alle restlichen Lernpunkte)", CH_Strength_all);
 	Info_AddChoice(CH_Training_STR, "Stärke (für beste Nahkampfwaffe)", CH_Strength_Weapon);
 	if (hero.LP >= 20 * LPCOST_ATTRIBUTE_STRENGTH)
@@ -1023,7 +1023,7 @@ func int CH_Training_DEX_Condition()
 func void CH_Training_DEX_Info()
 {
 	Info_ClearChoices(CH_Training_DEX);
-	Info_AddChoice(CH_Training_DEX, DIALOG_ENDE, CH_Training_DEX_BACK);
+	Info_AddChoice(CH_Training_DEX, DIALOG_BACK, CH_Training_DEX_BACK);
 	Info_AddChoice(CH_Training_DEX, "Geschick (alle restlichen Lernpunkte)", CH_Dexterity_all);
 	Info_AddChoice(CH_Training_DEX, "Geschick (für beste Fernkampfwaffe)", CH_Dexterity_Weapon);
 	if (hero.LP >= 20)

--- a/Scripts/content/AI/Test_Skripts/StoryHelper.d
+++ b/Scripts/content/AI/Test_Skripts/StoryHelper.d
@@ -95,7 +95,7 @@ func void StoryHelper_INFO2_Info()
 {
 	Info_ClearChoices(StoryHelper_INFO2);
 
-	Info_AddChoice(StoryHelper_INFO2, DIALOG_ENDE, StoryHelper_BACK2);
+	Info_AddChoice(StoryHelper_INFO2, DIALOG_BACK, StoryHelper_BACK2);
 	Info_AddChoice(StoryHelper_INFO2, "II:  Vorbereitung für die Beschwörung", StoryHelper_PrepareRitual);
 	Info_AddChoice(StoryHelper_INFO2, "II:  Hole den Almanach", StoryHelper_CorKalom_BringBook_RUNNING);
 	Info_AddChoice(StoryHelper_INFO2, "II:  Hole die MCQ-Eier", StoryHelper_CorKalom_BringMCQBalls_RUNNING);
@@ -341,7 +341,7 @@ func void StoryHelper_INFO4_Info()
 {
 	Info_ClearChoices(StoryHelper_INFO4);
 
-	Info_AddChoice(StoryHelper_INFO4, DIALOG_ENDE, StoryHelper_BACK4);
+	Info_AddChoice(StoryHelper_INFO4, DIALOG_BACK, StoryHelper_BACK4);
 	Info_AddChoice(StoryHelper_INFO4, "IV:  Suche Teile für Ulu-Mulu", StoryHelper_SearchForUluMulu);
 	Info_AddChoice(StoryHelper_INFO4, "IV:  Bereit für Angriff auf die Freie Mine", StoryHelper_AttackFreeMine);
 	Info_AddChoice(StoryHelper_INFO4, "IV:  Xardas  - Finde Ork Schamanen", StoryHelper_XardasFindOrcShaman);
@@ -580,7 +580,7 @@ func void StoryHelper_INFO5_Info()
 {
 	Info_ClearChoices(StoryHelper_INFO5);
 
-	Info_AddChoice(StoryHelper_INFO5, DIALOG_ENDE, StoryHelper_BACK5);
+	Info_AddChoice(StoryHelper_INFO5, DIALOG_BACK, StoryHelper_BACK5);
 	Info_AddChoice(StoryHelper_INFO5, "V:  URIZIEL ist aufgeladen", StoryHelper_UrizielLoaded);
 	Info_AddChoice(StoryHelper_INFO5, "V:  Bereit für das Laden von URIZIEL", StoryHelper_LoadUriziel);
 	Info_AddChoice(StoryHelper_INFO5, "V:  Erforsche den versunkenen Turm", StoryHelper_ExploreSunkenTower);

--- a/Scripts/content/Items/MissionItems_5.d
+++ b/Scripts/content/Items/MissionItems_5.d
@@ -434,7 +434,7 @@ instance DungeonKey(C_Item)
 
 	description					= name;
 	text[0]						= "Öffnet den Kerker";							count[0] = 0;
-	text[1]						= "des Alten Lagers.";							count[0] = 0;
+	text[1]						= "des Alten Lagers.";							count[1] = 0;
 };
 
 // ---------------------------------------------------------------------

--- a/Scripts/content/Story/B/B_AssignAmbientInfos_Grd_7.d
+++ b/Scripts/content/Story/B/B_AssignAmbientInfos_Grd_7.d
@@ -113,7 +113,7 @@ func void Info_grd_7_DasLager_Info()
 	AI_Output(self, other, "Info_grd_7_DasLager_07_01"); //Nein. Die meisten hier sind einfache Buddler.
 	AI_Output(self, other, "Info_grd_7_DasLager_07_02"); //Nur wir Gardisten und die Schatten sind Gomez' Leute.
 	Info_ClearChoices(Info_grd_7_DasLager);
-	Info_AddChoice(Info_grd_7_DasLager, DIALOG_ENDE, Info_grd_7_DasLager_Zurueck);
+	Info_AddChoice(Info_grd_7_DasLager, DIALOG_BACK, Info_grd_7_DasLager_Zurueck);
 	Info_AddChoice(Info_grd_7_DasLager, "Was tun die Gardisten?", Info_grd_7_DasLager_Gardisten);
 	Info_AddChoice(Info_grd_7_DasLager, "Was ist die Aufgabe der Schatten?", Info_grd_7_DasLager_Schatten);
 	Info_AddChoice(Info_grd_7_DasLager, "Wofür sind die Buddler da?", Info_grd_7_DasLager_Buddler);

--- a/Scripts/content/Story/NPC/TPL_1447_Templer.d
+++ b/Scripts/content/Story/NPC/TPL_1447_Templer.d
@@ -29,7 +29,7 @@ instance TPL_1447_Templer(Npc_Default)
 	Mdl_SetVisual(self, "HUMANS.MDS");
 	Mdl_ApplyOverlayMDS(self, "Humans_Mage.mds");
 	//						body mesh,				bdytex,	skin,		head mesh,			headtex,	teethtex,	armor
-	Mdl_SetVisualBody(self,	"hum_body_Naked0",		1,		1,			"Hum_Head_Bald",	117,		2,			TPL_ARMOR_L);
+	Mdl_SetVisualBody(self,	"hum_body_Naked0",		1,		1,			"Hum_Head_Bald",	117,		2,			TPL_ARMOR_M);
 
 	B_Scale(self);
 	Mdl_SetModelFatness(self, -1);

--- a/Scripts/content/Story/NPC/TPL_1448_Templer.d
+++ b/Scripts/content/Story/NPC/TPL_1448_Templer.d
@@ -29,7 +29,7 @@ instance TPL_1448_Templer(Npc_Default)
 	Mdl_SetVisual(self, "HUMANS.MDS");
 	Mdl_ApplyOverlayMDS(self, "Humans_Mage.mds");
 	//						body mesh,				bdytex,	skin,		head mesh,			headtex,	teethtex,	armor
-	Mdl_SetVisualBody(self,	"hum_body_Naked0",		1,		1,			"Hum_Head_Bald",	117,		2,			TPL_ARMOR_L);
+	Mdl_SetVisualBody(self,	"hum_body_Naked0",		1,		1,			"Hum_Head_Bald",	117,		2,			TPL_ARMOR_M);
 
 	B_Scale(self);
 	Mdl_SetModelFatness(self, -1);

--- a/Scripts/content/Story/NPC/TPL_1449_Templer.d
+++ b/Scripts/content/Story/NPC/TPL_1449_Templer.d
@@ -29,7 +29,7 @@ instance TPL_1449_Templer(Npc_Default)
 	Mdl_SetVisual(self, "HUMANS.MDS");
 	Mdl_ApplyOverlayMDS(self, "Humans_Mage.mds");
 	//						body mesh,				bdytex,	skin,		head mesh,			headtex,	teethtex,	armor
-	Mdl_SetVisualBody(self,	"hum_body_Naked0",		1,		1,			"Hum_Head_Bald",	117,		2,			TPL_ARMOR_L);
+	Mdl_SetVisualBody(self,	"hum_body_Naked0",		1,		1,			"Hum_Head_Bald",	117,		2,			TPL_ARMOR_M);
 
 	B_Scale(self);
 	Mdl_SetModelFatness(self, -1);

--- a/Scripts/content/Story/NPC/TPL_1450_Templer.d
+++ b/Scripts/content/Story/NPC/TPL_1450_Templer.d
@@ -29,7 +29,7 @@ instance TPL_1450_Templer(Npc_Default)
 	Mdl_SetVisual(self, "HUMANS.MDS");
 	Mdl_ApplyOverlayMDS(self, "Humans_Mage.mds");
 	//						body mesh,				bdytex,	skin,		head mesh,			headtex,	teethtex,	armor
-	Mdl_SetVisualBody(self,	"hum_body_Naked0",		1,		1,			"Hum_Head_Bald",	117,		2,			TPL_ARMOR_L);
+	Mdl_SetVisualBody(self,	"hum_body_Naked0",		1,		1,			"Hum_Head_Bald",	117,		2,			TPL_ARMOR_M);
 
 	B_Scale(self);
 	Mdl_SetModelFatness(self, -1);

--- a/Scripts/content/Story/NPC/TPL_1452_Templer.d
+++ b/Scripts/content/Story/NPC/TPL_1452_Templer.d
@@ -29,7 +29,7 @@ instance TPL_1452_Templer(Npc_Default)
 	Mdl_SetVisual(self, "HUMANS.MDS");
 	Mdl_ApplyOverlayMDS(self, "Humans_Mage.mds");
 	//						body mesh,				bdytex,	skin,		head mesh,			headtex,	teethtex,	armor
-	Mdl_SetVisualBody(self,	"hum_body_Naked0",		1,		1,			"Hum_Head_Bald",	117,		2,			TPL_ARMOR_L);
+	Mdl_SetVisualBody(self,	"hum_body_Naked0",		1,		1,			"Hum_Head_Bald",	117,		2,			TPL_ARMOR_M);
 
 	B_Scale(self);
 	Mdl_SetModelFatness(self, -1);

--- a/Scripts/content/Story/NPC/TPL_1453_Templer.d
+++ b/Scripts/content/Story/NPC/TPL_1453_Templer.d
@@ -29,7 +29,7 @@ instance TPL_1453_Templer(Npc_Default)
 	Mdl_SetVisual(self, "HUMANS.MDS");
 	Mdl_ApplyOverlayMDS(self, "Humans_Mage.mds");
 	//						body mesh,				bdytex,	skin,		head mesh,			headtex,	teethtex,	armor
-	Mdl_SetVisualBody(self,	"hum_body_Naked0",		1,		1,			"Hum_Head_Bald",	117,		2,			TPL_ARMOR_L);
+	Mdl_SetVisualBody(self,	"hum_body_Naked0",		1,		1,			"Hum_Head_Bald",	117,		2,			TPL_ARMOR_M);
 
 	B_Scale(self);
 	Mdl_SetModelFatness(self, -1);

--- a/Scripts/content/Story/NPC/TPL_1454_Templer.d
+++ b/Scripts/content/Story/NPC/TPL_1454_Templer.d
@@ -29,7 +29,7 @@ instance TPL_1454_Templer(Npc_Default)
 	Mdl_SetVisual(self, "HUMANS.MDS");
 	Mdl_ApplyOverlayMDS(self, "Humans_Mage.mds");
 	//						body mesh,				bdytex,	skin,		head mesh,			headtex,	teethtex,	armor
-	Mdl_SetVisualBody(self,	"hum_body_Naked0",		1,		1,			"Hum_Head_Bald",	117,		2,			TPL_ARMOR_L);
+	Mdl_SetVisualBody(self,	"hum_body_Naked0",		1,		1,			"Hum_Head_Bald",	117,		2,			TPL_ARMOR_M);
 
 	B_Scale(self);
 	Mdl_SetModelFatness(self, -1);

--- a/Scripts/content/Story/NPC/TPL_1455_GorBoba.d
+++ b/Scripts/content/Story/NPC/TPL_1455_GorBoba.d
@@ -29,7 +29,7 @@ instance TPL_1455_GorBoba(Npc_Default)
 	Mdl_SetVisual(self, "HUMANS.MDS");
 	Mdl_ApplyOverlayMDS(self, "Humans_Mage.mds");
 	//						body mesh,				bdytex,	skin,		head mesh,			headtex,	teethtex,	armor
-	Mdl_SetVisualBody(self,	"hum_body_Naked0",		1,		1,			"Hum_Head_Bald",	117,		2,			TPL_ARMOR_L);
+	Mdl_SetVisualBody(self,	"hum_body_Naked0",		1,		1,			"Hum_Head_Bald",	117,		2,			TPL_ARMOR_M);
 
 	B_Scale(self);
 	Mdl_SetModelFatness(self, -1);

--- a/Scripts/content/Story/NPC/TPL_1456_Templer.d
+++ b/Scripts/content/Story/NPC/TPL_1456_Templer.d
@@ -29,7 +29,7 @@ instance TPL_1456_Templer(Npc_Default)
 	Mdl_SetVisual(self, "HUMANS.MDS");
 	Mdl_ApplyOverlayMDS(self, "Humans_Mage.mds");
 	//						body mesh,				bdytex,	skin,		head mesh,			headtex,	teethtex,	armor
-	Mdl_SetVisualBody(self,	"hum_body_Naked0",		1,		1,			"Hum_Head_Bald",	117,		2,			TPL_ARMOR_L);
+	Mdl_SetVisualBody(self,	"hum_body_Naked0",		1,		1,			"Hum_Head_Bald",	117,		2,			TPL_ARMOR_M);
 
 	B_Scale(self);
 	Mdl_SetModelFatness(self, -1);

--- a/Scripts/content/Story/NPC/TPL_1457_Templer.d
+++ b/Scripts/content/Story/NPC/TPL_1457_Templer.d
@@ -29,7 +29,7 @@ instance TPL_1457_Templer(Npc_Default)
 	Mdl_SetVisual(self, "HUMANS.MDS");
 	Mdl_ApplyOverlayMDS(self, "Humans_Mage.mds");
 	//						body mesh,				bdytex,	skin,		head mesh,			headtex,	teethtex,	armor
-	Mdl_SetVisualBody(self,	"hum_body_Naked0",		1,		1,			"Hum_Head_Bald",	117,		2,			TPL_ARMOR_L);
+	Mdl_SetVisualBody(self,	"hum_body_Naked0",		1,		1,			"Hum_Head_Bald",	117,		2,			TPL_ARMOR_M);
 
 	B_Scale(self);
 	Mdl_SetModelFatness(self, -1);

--- a/Scripts/content/Story/NPC/TPL_1458_Templer.d
+++ b/Scripts/content/Story/NPC/TPL_1458_Templer.d
@@ -29,7 +29,7 @@ instance TPL_1458_Templer(Npc_Default)
 	Mdl_SetVisual(self, "HUMANS.MDS");
 	Mdl_ApplyOverlayMDS(self, "Humans_Mage.mds");
 	//						body mesh,				bdytex,	skin,		head mesh,			headtex,	teethtex,	armor
-	Mdl_SetVisualBody(self,	"hum_body_Naked0",		1,		1,			"Hum_Head_Bald",	117,		2,			TPL_ARMOR_L);
+	Mdl_SetVisualBody(self,	"hum_body_Naked0",		1,		1,			"Hum_Head_Bald",	117,		2,			TPL_ARMOR_M);
 
 	B_Scale(self);
 	Mdl_SetModelFatness(self, -1);

--- a/Scripts/content/Story/NPC/TPL_1459_Templer.d
+++ b/Scripts/content/Story/NPC/TPL_1459_Templer.d
@@ -29,7 +29,7 @@ instance TPL_1459_Templer(Npc_Default)
 	Mdl_SetVisual(self, "HUMANS.MDS");
 	Mdl_ApplyOverlayMDS(self, "Humans_Mage.mds");
 	//						body mesh,				bdytex,	skin,		head mesh,			headtex,	teethtex,	armor
-	Mdl_SetVisualBody(self,	"hum_body_Naked0",		1,		1,			"Hum_Head_Bald",	117,		2,			TPL_ARMOR_L);
+	Mdl_SetVisualBody(self,	"hum_body_Naked0",		1,		1,			"Hum_Head_Bald",	117,		2,			TPL_ARMOR_M);
 
 	B_Scale(self);
 	Mdl_SetModelFatness(self, -1);

--- a/Scripts/content/Story/NPC/TPL_1460_Templer.d
+++ b/Scripts/content/Story/NPC/TPL_1460_Templer.d
@@ -29,7 +29,7 @@ instance TPL_1460_Templer(Npc_Default)
 	Mdl_SetVisual(self, "HUMANS.MDS");
 	Mdl_ApplyOverlayMDS(self, "Humans_Mage.mds");
 	//						body mesh,				bdytex,	skin,		head mesh,			headtex,	teethtex,	armor
-	Mdl_SetVisualBody(self,	"hum_body_Naked0",		1,		1,			"Hum_Head_Bald",	117,		2,			TPL_ARMOR_L);
+	Mdl_SetVisualBody(self,	"hum_body_Naked0",		1,		1,			"Hum_Head_Bald",	117,		2,			TPL_ARMOR_M);
 
 	B_Scale(self);
 	Mdl_SetModelFatness(self, -1);

--- a/Scripts/content/Story/NPC/TPL_1461_Templer.d
+++ b/Scripts/content/Story/NPC/TPL_1461_Templer.d
@@ -29,7 +29,7 @@ instance TPL_1461_Templer(Npc_Default)
 	Mdl_SetVisual(self, "HUMANS.MDS");
 	Mdl_ApplyOverlayMDS(self, "Humans_Mage.mds");
 	//						body mesh,				bdytex,	skin,		head mesh,			headtex,	teethtex,	armor
-	Mdl_SetVisualBody(self,	"hum_body_Naked0",		1,		1,			"Hum_Head_Bald",	117,		2,			TPL_ARMOR_L);
+	Mdl_SetVisualBody(self,	"hum_body_Naked0",		1,		1,			"Hum_Head_Bald",	117,		2,			TPL_ARMOR_M);
 
 	B_Scale(self);
 	Mdl_SetModelFatness(self, -1);

--- a/Scripts/content/Story/NPC/TPL_1462_Templer.d
+++ b/Scripts/content/Story/NPC/TPL_1462_Templer.d
@@ -29,7 +29,7 @@ instance TPL_1462_Templer(Npc_Default)
 	Mdl_SetVisual(self, "HUMANS.MDS");
 	Mdl_ApplyOverlayMDS(self, "Humans_Mage.mds");
 	//						body mesh,				bdytex,	skin,		head mesh,			headtex,	teethtex,	armor
-	Mdl_SetVisualBody(self,	"hum_body_Naked0",		1,		1,			"Hum_Head_Bald",	117,		2,			TPL_ARMOR_L);
+	Mdl_SetVisualBody(self,	"hum_body_Naked0",		1,		1,			"Hum_Head_Bald",	117,		2,			TPL_ARMOR_M);
 
 	B_Scale(self);
 	Mdl_SetModelFatness(self, -1);

--- a/Scripts/content/Story/NPC/Tpl_1400_GorNaBar.d
+++ b/Scripts/content/Story/NPC/Tpl_1400_GorNaBar.d
@@ -24,7 +24,7 @@ instance TPL_1400_GorNaBar(Npc_Default)
 	Mdl_SetVisual(self, "HUMANS.MDS");
 	Mdl_ApplyOverlayMDS(self, "Humans_Mage.mds");
 	//						body mesh,				bdytex,	skin,		head mesh,			headtex,	teethtex,	armor
-	Mdl_SetVisualBody(self,	"hum_body_Naked0",		1,		2,			"Hum_Head_FatBald",	16,			1,			TPL_ARMOR_L);
+	Mdl_SetVisualBody(self,	"hum_body_Naked0",		1,		2,			"Hum_Head_FatBald",	16,			1,			TPL_ARMOR_M);
 
 	B_Scale(self);
 	Mdl_SetModelFatness(self, 0);

--- a/Scripts/content/Story/NPC/Tpl_1401_GorNaKosh.d
+++ b/Scripts/content/Story/NPC/Tpl_1401_GorNaKosh.d
@@ -24,7 +24,7 @@ instance TPL_1401_GorNaKosh(Npc_Default)
 	Mdl_SetVisual(self, "HUMANS.MDS");
 	Mdl_ApplyOverlayMDS(self, "Humans_Mage.mds");
 	//						body mesh,				bdytex,	skin,		head mesh,			headtex,	teethtex,	armor
-	Mdl_SetVisualBody(self,	"hum_body_Naked0",		0,		0,			"Hum_Head_FatBald",	15,			2,			TPL_ARMOR_L);
+	Mdl_SetVisualBody(self,	"hum_body_Naked0",		0,		0,			"Hum_Head_FatBald",	15,			2,			TPL_ARMOR_M);
 
 	B_Scale(self);
 	Mdl_SetModelFatness(self, 0);

--- a/Scripts/content/Story/NPC/Tpl_1403_Templer.d
+++ b/Scripts/content/Story/NPC/Tpl_1403_Templer.d
@@ -24,7 +24,7 @@ instance TPL_1403_Templer(Npc_Default)
 	Mdl_SetVisual(self, "HUMANS.MDS");
 	Mdl_ApplyOverlayMDS(self, "Humans_Mage.mds");
 	//						body mesh,				bdytex,	skin,		head mesh,			headtex,	teethtex,	armor
-	Mdl_SetVisualBody(self,	"hum_body_Naked0",		0,		1,			"Hum_Head_FatBald",	60,			1,			TPL_ARMOR_L);
+	Mdl_SetVisualBody(self,	"hum_body_Naked0",		0,		1,			"Hum_Head_FatBald",	60,			1,			TPL_ARMOR_M);
 
 	B_Scale(self);
 	Mdl_SetModelFatness(self, -1);

--- a/Scripts/content/Story/NPC/Tpl_1404_Templer.d
+++ b/Scripts/content/Story/NPC/Tpl_1404_Templer.d
@@ -23,7 +23,7 @@ instance TPL_1404_Templer(Npc_Default)
 	Mdl_SetVisual(self, "HUMANS.MDS");
 	Mdl_ApplyOverlayMDS(self, "Humans_Mage.mds");
 	//						body mesh,				bdytex,	skin,		head mesh,			headtex,	teethtex,	armor
-	Mdl_SetVisualBody(self,	"hum_body_Naked0",		1,		2,			"Hum_Head_Bald",	13,			1,			TPL_ARMOR_L);
+	Mdl_SetVisualBody(self,	"hum_body_Naked0",		1,		2,			"Hum_Head_Bald",	13,			1,			TPL_ARMOR_M);
 
 	B_Scale(self);
 	Mdl_SetModelFatness(self, -1);

--- a/Scripts/content/Story/NPC/Tpl_1406_Templer.d
+++ b/Scripts/content/Story/NPC/Tpl_1406_Templer.d
@@ -23,7 +23,7 @@ instance TPL_1406_Templer(Npc_Default)
 	Mdl_SetVisual(self, "HUMANS.MDS");
 	Mdl_ApplyOverlayMDS(self, "Humans_Mage.mds");
 	//						body mesh,				bdytex,	skin,		head mesh,			headtex,	teethtex,	armor
-	Mdl_SetVisualBody(self,	"hum_body_Naked0",		1,		1,			"Hum_Head_Bald",	63,			2,			TPL_ARMOR_L);
+	Mdl_SetVisualBody(self,	"hum_body_Naked0",		1,		1,			"Hum_Head_Bald",	63,			2,			TPL_ARMOR_H);
 
 	B_Scale(self);
 	Mdl_SetModelFatness(self, 0);

--- a/Scripts/content/Story/NPC/Tpl_1407_Templer.d
+++ b/Scripts/content/Story/NPC/Tpl_1407_Templer.d
@@ -24,7 +24,7 @@ instance TPL_1407_Templer(Npc_Default)
 	Mdl_SetVisual(self, "HUMANS.MDS");
 	Mdl_ApplyOverlayMDS(self, "Humans_Mage.mds");
 	//						body mesh,				bdytex,	skin,		head mesh,			headtex,	teethtex,	armor
-	Mdl_SetVisualBody(self,	"hum_body_Naked0",		1,		1,			"Hum_Head_Psionic",	64,			1,			TPL_ARMOR_L);
+	Mdl_SetVisualBody(self,	"hum_body_Naked0",		1,		1,			"Hum_Head_Psionic",	64,			1,			TPL_ARMOR_M);
 
 	B_Scale(self);
 	Mdl_SetModelFatness(self, -1);

--- a/Scripts/content/Story/NPC/Tpl_1409_Templer.d
+++ b/Scripts/content/Story/NPC/Tpl_1409_Templer.d
@@ -24,7 +24,7 @@ instance TPL_1409_Templer(Npc_Default)
 	Mdl_SetVisual(self, "HUMANS.MDS");
 	Mdl_ApplyOverlayMDS(self, "Humans_Mage.mds");
 	//						body mesh,				bdytex,	skin,		head mesh,			headtex,	teethtex,	armor
-	Mdl_SetVisualBody(self,	"hum_body_Naked0",		1,		1,			"Hum_Head_Bald",	65,			1,			TPL_ARMOR_L);
+	Mdl_SetVisualBody(self,	"hum_body_Naked0",		1,		1,			"Hum_Head_Bald",	65,			1,			TPL_ARMOR_M);
 
 	B_Scale(self);
 	Mdl_SetModelFatness(self, -1);

--- a/Scripts/content/Story/NPC/Tpl_1410_Templer.d
+++ b/Scripts/content/Story/NPC/Tpl_1410_Templer.d
@@ -24,7 +24,7 @@ instance TPL_1410_Templer(Npc_Default)
 	Mdl_SetVisual(self, "HUMANS.MDS");
 	Mdl_ApplyOverlayMDS(self, "Humans_Mage.mds");
 	//						body mesh,				bdytex,	skin,		head mesh,			headtex,	teethtex,	armor
-	Mdl_SetVisualBody(self,	"hum_body_Naked0",		1,		1,			"Hum_Head_Bald",	64,			4,			TPL_ARMOR_L);
+	Mdl_SetVisualBody(self,	"hum_body_Naked0",		1,		1,			"Hum_Head_Bald",	64,			4,			TPL_ARMOR_M);
 
 	B_Scale(self);
 	Mdl_SetModelFatness(self, -1);

--- a/Scripts/content/Story/NPC/Tpl_1415_Templer.d
+++ b/Scripts/content/Story/NPC/Tpl_1415_Templer.d
@@ -23,7 +23,7 @@ instance TPL_1415_Templer(Npc_Default)
 	Mdl_SetVisual(self, "HUMANS.MDS");
 	Mdl_ApplyOverlayMDS(self, "Humans_Militia.mds");
 	//						body mesh,				bdytex,	skin,		head mesh,			headtex,	teethtex,	armor
-	Mdl_SetVisualBody(self,	"hum_body_Naked0",		0,		1,			"Hum_Head_Bald",	59,			1,			TPL_ARMOR_L);
+	Mdl_SetVisualBody(self,	"hum_body_Naked0",		0,		1,			"Hum_Head_Bald",	59,			1,			TPL_ARMOR_M);
 
 	B_Scale(self);
 	Mdl_SetModelFatness(self, -1);

--- a/Scripts/content/Story/NPC/Tpl_1416_Templer.d
+++ b/Scripts/content/Story/NPC/Tpl_1416_Templer.d
@@ -23,7 +23,7 @@ instance TPL_1416_Templer(Npc_Default)
 	Mdl_SetVisual(self, "HUMANS.MDS");
 	Mdl_ApplyOverlayMDS(self, "Humans_Militia.mds");
 	//						body mesh,				bdytex,	skin,		head mesh,			headtex,	teethtex,	armor
-	Mdl_SetVisualBody(self,	"hum_body_Naked0",		1,		1,			"Hum_Head_Psionic",	59,			2,			TPL_ARMOR_L);
+	Mdl_SetVisualBody(self,	"hum_body_Naked0",		1,		1,			"Hum_Head_Psionic",	59,			2,			TPL_ARMOR_M);
 
 	B_Scale(self);
 	Mdl_SetModelFatness(self, -1);

--- a/Scripts/content/Story/NPC/Tpl_1423_Templer.d
+++ b/Scripts/content/Story/NPC/Tpl_1423_Templer.d
@@ -23,7 +23,7 @@ instance TPL_1423_Templer(Npc_Default)
 	Mdl_SetVisual(self, "HUMANS.MDS");
 	Mdl_ApplyOverlayMDS(self, "Humans_Mage.mds");
 	//						body mesh,				bdytex,	skin,		head mesh,			headtex,	teethtex,	armor
-	Mdl_SetVisualBody(self,	"hum_body_Naked0",		1,		1,			"Hum_Head_Psionic",	64,			1,			TPL_ARMOR_L);
+	Mdl_SetVisualBody(self,	"hum_body_Naked0",		1,		1,			"Hum_Head_Psionic",	64,			1,			TPL_ARMOR_M);
 
 	B_Scale(self);
 	Mdl_SetModelFatness(self, -1);

--- a/Scripts/content/Story/NPC/Tpl_1424_Templer.d
+++ b/Scripts/content/Story/NPC/Tpl_1424_Templer.d
@@ -23,7 +23,7 @@ instance TPL_1424_Templer(Npc_Default)
 	Mdl_SetVisual(self, "HUMANS.MDS");
 	Mdl_ApplyOverlayMDS(self, "Humans_Mage.mds");
 	//						body mesh,				bdytex,	skin,		head mesh,			headtex,	teethtex,	armor
-	Mdl_SetVisualBody(self,	"hum_body_Naked0",		0,		1,			"Hum_Head_FatBald",	60,			1,			TPL_ARMOR_L);
+	Mdl_SetVisualBody(self,	"hum_body_Naked0",		0,		1,			"Hum_Head_FatBald",	60,			1,			TPL_ARMOR_M);
 
 	B_Scale(self);
 	Mdl_SetModelFatness(self, -1);

--- a/Scripts/content/Story/NPC/Tpl_1425_Templer.d
+++ b/Scripts/content/Story/NPC/Tpl_1425_Templer.d
@@ -23,7 +23,7 @@ instance TPL_1425_Templer(Npc_Default)
 	Mdl_SetVisual(self, "HUMANS.MDS");
 	Mdl_ApplyOverlayMDS(self, "Humans_Mage.mds");
 	//						body mesh,				bdytex,	skin,		head mesh,			headtex,	teethtex,	armor
-	Mdl_SetVisualBody(self,	"hum_body_Naked0",		1,		1,			"Hum_Head_Bald",	65,			1,			TPL_ARMOR_L);
+	Mdl_SetVisualBody(self,	"hum_body_Naked0",		1,		1,			"Hum_Head_Bald",	65,			1,			TPL_ARMOR_M);
 
 	B_Scale(self);
 	Mdl_SetModelFatness(self, -1);

--- a/Scripts/content/Story/NPC/Tpl_1432_Templer.d
+++ b/Scripts/content/Story/NPC/Tpl_1432_Templer.d
@@ -23,7 +23,7 @@ instance TPL_1432_Templer(Npc_Default)
 	Mdl_SetVisual(self, "HUMANS.MDS");
 	Mdl_ApplyOverlayMDS(self, "Humans_Militia.mds");
 	//						body mesh,				bdytex,	skin,		head mesh,			headtex,	teethtex,	armor
-	Mdl_SetVisualBody(self,	"hum_body_Naked0",		1,		1,			"Hum_Head_Psionic",	59,			2,			TPL_ARMOR_L);
+	Mdl_SetVisualBody(self,	"hum_body_Naked0",		1,		1,			"Hum_Head_Psionic",	59,			2,			TPL_ARMOR_M);
 
 	B_Scale(self);
 	Mdl_SetModelFatness(self, -1);

--- a/Scripts/content/Story/NPC/Tpl_1433_GorNaVid.d
+++ b/Scripts/content/Story/NPC/Tpl_1433_GorNaVid.d
@@ -24,7 +24,7 @@ instance TPL_1433_GorNaVid(Npc_Default)
 	Mdl_SetVisual(self, "HUMANS.MDS");
 	Mdl_ApplyOverlayMDS(self, "Humans_Mage.mds");
 	//						body mesh,				bdytex,	skin,		head mesh,			headtex,	teethtex,	armor
-	Mdl_SetVisualBody(self,	"hum_body_Naked0",		1,		1,			"Hum_Head_Psionic",	20,			1,			TPL_ARMOR_L);
+	Mdl_SetVisualBody(self,	"hum_body_Naked0",		1,		1,			"Hum_Head_Psionic",	20,			1,			TPL_ARMOR_M);
 
 	B_Scale(self);
 	Mdl_SetModelFatness(self, -1);

--- a/Scripts/content/Story/NPC/Tpl_1434_Templer.d
+++ b/Scripts/content/Story/NPC/Tpl_1434_Templer.d
@@ -23,7 +23,7 @@ instance TPL_1434_Templer(Npc_Default)
 	Mdl_SetVisual(self, "HUMANS.MDS");
 	Mdl_ApplyOverlayMDS(self, "Humans_Mage.mds");
 	//						body mesh,				bdytex,	skin,		head mesh,			headtex,	teethtex,	armor
-	Mdl_SetVisualBody(self,	"hum_body_Naked0",		1,		1,			"Hum_Head_Bald",	65,			1,			TPL_ARMOR_L);
+	Mdl_SetVisualBody(self,	"hum_body_Naked0",		1,		1,			"Hum_Head_Bald",	65,			1,			TPL_ARMOR_M);
 
 	B_Scale(self);
 	Mdl_SetModelFatness(self, -1);

--- a/Scripts/content/Story/NPC/Tpl_1435_Templer.d
+++ b/Scripts/content/Story/NPC/Tpl_1435_Templer.d
@@ -22,7 +22,7 @@ instance TPL_1435_Templer(Npc_Default)
 	Mdl_SetVisual(self, "HUMANS.MDS");
 	Mdl_ApplyOverlayMDS(self, "Humans_Mage.mds");
 	//						body mesh,				bdytex,	skin,		head mesh,			headtex,	teethtex,	armor
-	Mdl_SetVisualBody(self,	"hum_body_Naked0",		0,		1,			"Hum_Head_FatBald",	60,			1,			TPL_ARMOR_L);
+	Mdl_SetVisualBody(self,	"hum_body_Naked0",		0,		1,			"Hum_Head_FatBald",	60,			1,			TPL_ARMOR_M);
 
 	B_Scale(self);
 	Mdl_SetModelFatness(self, -1);

--- a/Scripts/content/Story/NPC/Tpl_1437_Templer.d
+++ b/Scripts/content/Story/NPC/Tpl_1437_Templer.d
@@ -24,7 +24,7 @@ instance TPL_1437_Templer(Npc_Default)
 	Mdl_SetVisual(self, "HUMANS.MDS");
 	Mdl_ApplyOverlayMDS(self, "Humans_Mage.mds");
 	//						body mesh,				bdytex,	skin,		head mesh,			headtex,	teethtex,	armor
-	Mdl_SetVisualBody(self,	"hum_body_Naked0",		1,		1,			"Hum_Head_Bald",	65,			1,			TPL_ARMOR_L);
+	Mdl_SetVisualBody(self,	"hum_body_Naked0",		1,		1,			"Hum_Head_Bald",	65,			1,			TPL_ARMOR_M);
 
 	B_Scale(self);
 	Mdl_SetModelFatness(self, -1);

--- a/Scripts/content/Story/NPC/Tpl_1439_GorNaDrak.d
+++ b/Scripts/content/Story/NPC/Tpl_1439_GorNaDrak.d
@@ -23,7 +23,7 @@ instance TPL_1439_GorNaDrak(Npc_Default)
 	Mdl_SetVisual(self, "HUMANS.MDS");
 	Mdl_ApplyOverlayMDS(self, "Humans_Mage.mds");
 	//						body mesh,				bdytex,	skin,		head mesh,			headtex,	teethtex,	armor
-	Mdl_SetVisualBody(self,	"hum_body_Naked0",		1,		1,			"Hum_Head_Bald",	63,			2,			TPL_ARMOR_L);
+	Mdl_SetVisualBody(self,	"hum_body_Naked0",		1,		1,			"Hum_Head_Bald",	63,			2,			TPL_ARMOR_H);
 
 	B_Scale(self);
 	Mdl_SetModelFatness(self, 0);

--- a/Scripts/content/Story/NPC/Tpl_1440_Templer.d
+++ b/Scripts/content/Story/NPC/Tpl_1440_Templer.d
@@ -24,7 +24,7 @@ instance TPL_1440_Templer(Npc_Default)
 	Mdl_SetVisual(self, "HUMANS.MDS");
 	Mdl_ApplyOverlayMDS(self, "Humans_Mage.mds");
 	//						body mesh,				bdytex,	skin,		head mesh,			headtex,	teethtex,	armor
-	Mdl_SetVisualBody(self,	"hum_body_Naked0",		1,		1,			"Hum_Head_Psionic",	64,			1,			TPL_ARMOR_L);
+	Mdl_SetVisualBody(self,	"hum_body_Naked0",		1,		1,			"Hum_Head_Psionic",	64,			1,			TPL_ARMOR_M);
 
 	B_Scale(self);
 	Mdl_SetModelFatness(self, -1);

--- a/Scripts/content/Story/NPC/Tpl_1441_Templer.d
+++ b/Scripts/content/Story/NPC/Tpl_1441_Templer.d
@@ -24,7 +24,7 @@ instance TPL_1441_Templer(Npc_Default)
 	Mdl_SetVisual(self, "HUMANS.MDS");
 	Mdl_ApplyOverlayMDS(self, "Humans_Mage.mds");
 	//						body mesh,				bdytex,	skin,		head mesh,			headtex,	teethtex,	armor
-	Mdl_SetVisualBody(self,	"hum_body_Naked0",		0,		1,			"Hum_Head_FatBald",	60,			1,			TPL_ARMOR_L);
+	Mdl_SetVisualBody(self,	"hum_body_Naked0",		0,		1,			"Hum_Head_FatBald",	60,			1,			TPL_ARMOR_M);
 
 	B_Scale(self);
 	Mdl_SetModelFatness(self, -1);

--- a/Scripts/content/Story/NPC/Tpl_1442_Templer.d
+++ b/Scripts/content/Story/NPC/Tpl_1442_Templer.d
@@ -23,7 +23,7 @@ instance TPL_1442_Templer(Npc_Default)
 	Mdl_SetVisual(self, "HUMANS.MDS");
 	Mdl_ApplyOverlayMDS(self, "Humans_Mage.mds");
 	//						body mesh,				bdytex,	skin,		head mesh,			headtex,	teethtex,	armor
-	Mdl_SetVisualBody(self,	"hum_body_Naked0",		1,		2,			"Hum_Head_Bald",	13,			1,			TPL_ARMOR_L);
+	Mdl_SetVisualBody(self,	"hum_body_Naked0",		1,		2,			"Hum_Head_Bald",	13,			1,			TPL_ARMOR_M);
 
 	B_Scale(self);
 	Mdl_SetModelFatness(self, -1);

--- a/Scripts/content/Story/NPC/Tpl_1451_Templer.d
+++ b/Scripts/content/Story/NPC/Tpl_1451_Templer.d
@@ -29,7 +29,7 @@ instance TPL_1451_Templer(Npc_Default)
 	Mdl_SetVisual(self, "HUMANS.MDS");
 	Mdl_ApplyOverlayMDS(self, "Humans_Mage.mds");
 	//						body mesh,				bdytex,	skin,		head mesh,			headtex,	teethtex,	armor
-	Mdl_SetVisualBody(self,	"hum_body_Naked0",		1,		1,			"Hum_Head_Bald",	117,		2,			TPL_ARMOR_L);
+	Mdl_SetVisualBody(self,	"hum_body_Naked0",		1,		1,			"Hum_Head_Bald",	117,		2,			TPL_ARMOR_M);
 
 	B_Scale(self);
 	Mdl_SetModelFatness(self, -1);


### PR DESCRIPTION
Fixed the following mistakes:

- Beautification: Medium templar armors were mistakenly replaced with the light templar armor variant.
- Substitution: "ZURÜCK" was incorrectly replaced with "ENDE" in several cases.
- Count property redefinition in item instance fixed.